### PR TITLE
Add version bump GitHub Actions workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,114 @@
+name: Version Bump
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest SemVer tag
+        id: get_latest_tag
+        run: |
+          TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          echo "latest_tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Fetch merged PRs since last release
+        id: fetch_prs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: json
+          script: |
+            const latestTag = '${{ steps.get_latest_tag.outputs.latest_tag }}';
+            const { data: tags } = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const tag = tags.find(t => t.name === latestTag);
+            const tagSha = tag?.commit.sha;
+
+            const mergedPRs = [];
+            let page = 1;
+            let done = false;
+
+            while (!done) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed',
+                per_page: 100,
+                page,
+              });
+
+              if (prs.length === 0) break;
+
+              for (const pr of prs) {
+                if (pr.merged_at && pr.merge_commit_sha !== tagSha) {
+                  mergedPRs.push({
+                    number: pr.number,
+                    title: pr.title,
+                    labels: pr.labels.map(l => l.name),
+                    merged_at: pr.merged_at,
+                  });
+                }
+              }
+
+              page++;
+              done = prs.length < 100;
+            }
+
+            return mergedPRs;
+
+      - name: Determine next version
+        id: bump
+        run: |
+          BASE="${{ steps.get_latest_tag.outputs.latest_tag }}"
+          VERSION="${BASE#v}"
+
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          echo '${{ toJson(steps.fetch_prs.outputs.result) }}' > prs.json
+
+          bump="patch"
+          if grep -q '"breaking-change"' prs.json; then
+            bump="major"
+          elif grep -q '"feature"' prs.json; then
+            bump="minor"
+          fi
+
+          if [ "$bump" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "$bump" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+          echo "🔖 Nouvelle version : $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create and push new tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag ${{ steps.bump.outputs.new_tag }}
+          git push origin ${{ steps.bump.outputs.new_tag }}
+
+      - name: Delete 'stable' tag remotely (recyclable trigger)
+        run: |
+          git push origin :refs/tags/stable || true


### PR DESCRIPTION
This workflow automates semantic versioning by detecting changes since the last release. It calculates the next version (major, minor, or patch) based on PR labels and pushes the new tag. Additionally, it removes the remote 'stable' tag to ensure the workflow can be re-triggered as needed.