### PR TITLE
Refactor version bump workflow for tag-based automation

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,114 +1,75 @@
-name: Version Bump
+name: Auto Version & Tag
 
 on:
-  workflow_call:
+  push:
+    tags:
+      - stable
 
 permissions:
   contents: write
   pull-requests: read
 
 jobs:
-  bump_version:
+  auto_version:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Get latest SemVer tag
-        id: get_latest_tag
-        run: |
-          TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-          echo "latest_tag=$TAG" >> $GITHUB_OUTPUT
-
-      - name: Fetch merged PRs since last release
-        id: fetch_prs
-        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: json
-          script: |
-            const latestTag = '${{ steps.get_latest_tag.outputs.latest_tag }}';
-            const { data: tags } = await github.rest.repos.listTags({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const tag = tags.find(t => t.name === latestTag);
-            const tagSha = tag?.commit.sha;
+          fetch-depth: 0  # important pour voir les anciens tags
 
-            const mergedPRs = [];
-            let page = 1;
-            let done = false;
-
-            while (!done) {
-              const { data: prs } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'closed',
-                per_page: 100,
-                page,
-              });
-
-              if (prs.length === 0) break;
-
-              for (const pr of prs) {
-                if (pr.merged_at && pr.merge_commit_sha !== tagSha) {
-                  mergedPRs.push({
-                    number: pr.number,
-                    title: pr.title,
-                    labels: pr.labels.map(l => l.name),
-                    merged_at: pr.merged_at,
-                  });
-                }
-              }
-
-              page++;
-              done = prs.length < 100;
-            }
-
-            return mergedPRs;
-
-      - name: Determine next version
-        id: bump
-        run: |
-          BASE="${{ steps.get_latest_tag.outputs.latest_tag }}"
-          VERSION="${BASE#v}"
-
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-
-          echo '${{ toJson(steps.fetch_prs.outputs.result) }}' > prs.json
-
-          bump="patch"
-          if grep -q '"breaking-change"' prs.json; then
-            bump="major"
-          elif grep -q '"feature"' prs.json; then
-            bump="minor"
-          fi
-
-          if [ "$bump" = "major" ]; then
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-          elif [ "$bump" = "minor" ]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
-          else
-            PATCH=$((PATCH + 1))
-          fi
-
-          NEW_TAG="v$MAJOR.$MINOR.$PATCH"
-          echo "🔖 Nouvelle version : $NEW_TAG"
-          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
-
-      - name: Create and push new tag
+      - name: Set up Git
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git tag ${{ steps.bump.outputs.new_tag }}
-          git push origin ${{ steps.bump.outputs.new_tag }}
 
-      - name: Delete 'stable' tag remotely (recyclable trigger)
+      - name: Install GitHub CLI
+        uses: cli/cli-action@v2
+
+      - name: Compute next version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}  # ← ton token PAT orga ici
         run: |
-          git push origin :refs/tags/stable || true
+          # Get last tag or default to v0.0.0
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "🔖 Dernier tag: $LAST_TAG"
+
+          # Extract version parts
+          VERSION=${LAST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Get PRs closed since last tag
+          TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+          LABELS=$(gh pr list --search "is:merged merged:>$TAG_DATE" --json labels --jq '.[].labels[].name')
+
+          echo "📦 Labels trouvés: $LABELS"
+
+          BUMP="patch"
+          if echo "$LABELS" | grep -q "breaking-change"; then
+            BUMP="major"
+          elif echo "$LABELS" | grep -q "feature"; then
+            BUMP="minor"
+          fi
+
+          # Increment version
+          if [[ "$BUMP" == "major" ]]; then
+            ((MAJOR+=1)); MINOR=0; PATCH=0
+          elif [[ "$BUMP" == "minor" ]]; then
+            ((MINOR+=1)); PATCH=0
+          else
+            ((PATCH+=1))
+          fi
+
+          NEW_VERSION="v$MAJOR.$MINOR.$PATCH"
+          echo "🆕 Nouvelle version: $NEW_VERSION"
+
+          echo "new_tag=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: ${{ steps.version.outputs.new_tag }}
+        run: |
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"


### PR DESCRIPTION
Streamlined version bump workflow to utilize tag-based triggers and GitHub CLI for simpler, more robust versioning. Removed redundant steps for determining changes and calculating versions, improving maintainability and efficiency.