### PR TITLE
Update version-bump workflow to use workflow_call trigger

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,9 +1,7 @@
 name: Auto Version & Tag
 
 on:
-  push:
-    tags:
-      - stable
+  workflow_call:
 
 permissions:
   contents: write


### PR DESCRIPTION
Replaced the push tag trigger with workflow_call to enable this workflow to be invoked by other workflows. This change improves modularity and reusability of the version-bump process.