### PR TITLE
Enhance tag date extraction in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -40,8 +40,14 @@ jobs:
 
           echo "Dernier tag: $LAST_TAG"
 
-          # Extraire la date du dernier tag
-          TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+          # Vérifier que le tag existe réellement, sinon fixer une date ancienne
+          if git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
+            TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+          else
+            TAG_DATE="1970-01-01T00:00:00Z"
+          fi
+
+          echo "Date du dernier tag: $TAG_DATE"
 
           # Nettoyer le "v" et séparer la version
           VERSION=${LAST_TAG#v}


### PR DESCRIPTION
Ensure the script handles non-existent tags gracefully by setting a default date. This prevents errors when no valid tag is found, improving workflow robustness.